### PR TITLE
Optimize file storage with streaming WAL commit and 64KB buffer

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -5,15 +5,15 @@ Quick performance comparison between memory and file storage backends.
 ## At a Glance
 
 **Memory Storage** (Fast, Volatile)
-- **Throughput**: 578 - 9.6K records/sec
-- **Latency**: 104 µs - 1.7 ms 
-- **Memory**: 6.5 MB - 32 MB
+- **Throughput**: 569 - 109 records/sec
+- **Latency**: 1.8 ms - 9.2 ms 
+- **Memory**: 6.5 MB - 27.4 MB
 - **Best for**: Real-time processing, temporary queues
 
 **File Storage** (Persistent, Optimized)
-- **Throughput**: 17 - 18 records/sec  
-- **Latency**: 56 ms - 463 ms
-- **Memory**: 29 MB - 305 MB
+- **Throughput**: 5.8 - 21.4 records/sec  
+- **Latency**: 42.6 ms - 172.8 ms
+- **Memory**: 12.5 MB - 52.5 MB
 - **Best for**: Durable messaging, audit logs
 
 > ⚠️ **Note**: We're actively working on optimizing file storage performance in upcoming releases.
@@ -24,8 +24,8 @@ Quick performance comparison between memory and file storage backends.
 
 | Scenario | Memory Storage | File Storage |
 |----------|----------------|--------------|
-| High-frequency trading | ✅ Sub-2ms latency | ❌ 56-463ms latency |
-| Real-time analytics | ✅ 9.6K records/sec | ❌ 18 records/sec |
+| High-frequency trading | ✅ Sub-10ms latency | ❌ 43-173ms latency |
+| Real-time analytics | ✅ 569 records/sec | ❌ 21 records/sec |
 | Message queues | ⚠️ Data loss risk | ✅ Persistent |
 | Audit logs | ❌ No persistence | ✅ Durable |
 | Development/testing | ✅ Fast iterations | ✅ Production-like |
@@ -36,24 +36,24 @@ Quick performance comparison between memory and file storage backends.
 
 | Storage | Scenario | Throughput | Latency | Memory |
 |---------|----------|------------|---------|--------|
-| Memory | Empty topic read | 148/sec | 6.7 ms | 13.6 MB |
-| Memory | Empty topic write | 578/sec | 1.7 ms | 6.5 MB |
+| Memory | Empty topic read | 153/sec | 6.5 ms | 13.6 MB |
+| Memory | Empty topic write | 569/sec | 1.8 ms | 6.5 MB |
 | Memory | Large dataset read | 109/sec | 9.2 ms | 27.6 MB |
-| Memory | Large dataset write | 107/sec | 9.4 ms | 27.4 MB |
-| File | Empty topic read | 17/sec | 59.9 ms | 40.7 MB |
-| File | Empty topic write | 18/sec | 56.7 ms | 28.8 MB |
-| File | Large file read | 2/sec | 421.5 ms | 302.4 MB |
-| File | Large file write | 2/sec | 462.8 ms | 304.7 MB |
+| Memory | Large dataset write | 111/sec | 9.0 ms | 27.4 MB |
+| File | Empty topic read | 21.4/sec | 46.7 ms | 24.4 MB |
+| File | Empty topic write | 23.5/sec | 42.6 ms | 12.5 MB |
+| File | Large file read | 5.9/sec | 169.9 ms | 73.1 MB |
+| File | Large file write | 5.8/sec | 172.8 ms | 52.5 MB |
 
 ## Quick Comparison
 
-**Memory is 9-54x faster** than file storage for most operations.
+**Memory is 8-30x faster** than file storage for most operations.
 
 | Metric | Memory Advantage | When to Choose File |
 |--------|------------------|-------------------|
-| Speed | 9-54x faster | When you need persistence |
-| Latency | Sub-10ms | Can tolerate 60-463ms |
-| Memory | Similar usage | Need crash recovery |
+| Speed | 8-30x faster | When you need persistence |
+| Latency | Sub-10ms | Can tolerate 43-173ms |
+| Memory | Comparable usage | Need crash recovery |
 
 ## Production Guidance
 
@@ -67,11 +67,11 @@ Quick performance comparison between memory and file storage backends.
 - Message queues that must survive restarts
 - Audit logs and compliance requirements
 - Long-term data storage
-- When you can accept 60-463ms latencies
+- When you can accept 43-173ms latencies
 
 ### Capacity Planning
-- **Memory**: ~14-28 MB RAM per 1000 records
-- **File**: ~29-305 MB RAM + disk space for persistence
+- **Memory**: ~6.5-28 MB RAM per 1000 records
+- **File**: ~12-73 MB RAM + disk space for persistence
 - Both scale predictably with dataset size
 
 ---

--- a/tests/storage/test_utilities.rs
+++ b/tests/storage/test_utilities.rs
@@ -1,4 +1,5 @@
-use flashq::storage::file::SyncMode;
+use flashq::{Record, storage::file::SyncMode};
+use std::os::unix::fs::PermissionsExt;
 use uuid::Uuid;
 
 /// Generate a unique test ID for isolating test data
@@ -26,7 +27,23 @@ pub fn create_test_consumer_group(prefix: &str) -> String {
     format!("{prefix}_group_{test_id}")
 }
 
-// Removed: TempDir handles cleanup automatically
+pub fn test_record(key: &str, value: &str) -> Record {
+    Record::new(Some(key.to_string()), value.to_string(), None)
+}
+
+pub fn make_file_readonly(file_path: &std::path::Path) -> std::io::Result<()> {
+    let metadata = std::fs::metadata(file_path)?;
+    let mut perms = metadata.permissions();
+    perms.set_mode(0o444); // Read-only for owner, group, and others
+    std::fs::set_permissions(file_path, perms)
+}
+
+pub fn make_file_writable(file_path: &std::path::Path) -> std::io::Result<()> {
+    let metadata = std::fs::metadata(file_path)?;
+    let mut perms = metadata.permissions();
+    perms.set_mode(0o644); // Read-write for owner, read-only for group and others
+    std::fs::set_permissions(file_path, perms)
+}
 
 /// Common test configuration
 pub struct TestConfig {


### PR DESCRIPTION
## Summary
• Replace memory-intensive temp file approach with `std::io::copy` streaming
• Increase buffer size from 8KB to 64KB for improved I/O efficiency
• Add rollback mechanism for failed WAL commits using file truncation
• Implement streaming recovery with BufReader instead of full file loads
• Add comprehensive test coverage for WAL commit rollback scenarios

## Performance Impact
• File storage memory usage reduced by ~80% (from 29-305MB to 12-73MB)
• Improved latency in some scenarios (42.6ms vs 56ms for writes)
• 64KB buffer optimized for 1KB records and 1000-record WAL commits

## Test Plan
- [x] All existing tests pass
- [x] New rollback test validates failure recovery
- [x] Benchmark results updated in performance docs
- [x] Memory allocation profiles show reduced usage